### PR TITLE
add pip upgrade on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /guestbook
  
 ADD *.py /guestbook/
 ADD *.proto /guestbook/
-RUN pip install grpcio grpcio-tools
+RUN pip install --upgrade pip && \
+    pip install grpcio grpcio-tools
 RUN python -m grpc_tools.protoc \
 	guestbook.proto \
 	-I. --python_out=. --grpc_python_out=.


### PR DESCRIPTION
I added a pip upgrade on Dockerfile.

Without this modification, wheeling grpcio is too long to complete first step. 
By upgrading pip version from 9 to 20 (or more), we can access grpc's .whl file directly.  

## Reference
- https://github.com/grpc/grpc/issues/22815